### PR TITLE
Dereference relative IRIs

### DIFF
--- a/lib/prtimes_source.go
+++ b/lib/prtimes_source.go
@@ -3,6 +3,7 @@ package scraper
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -45,6 +46,7 @@ func (s *PRTimesSource) ScrapeFromDocument(doc *goquery.Document) (*feeds.Feed, 
 		Link:  &feeds.Link{Href: PRTimesUrl},
 	}
 
+	baseUrl, _ := url.Parse(PRTimesUrl)
 	var items []*feeds.Item
 	doc.Find("a.link-title-item-ordinary").Each(func(_ int, s *goquery.Selection) {
 		title := strings.TrimSpace(s.Text())
@@ -52,6 +54,12 @@ func (s *PRTimesSource) ScrapeFromDocument(doc *goquery.Document) (*feeds.Feed, 
 		if !ok {
 			return
 		}
+		refUrl, err := url.Parse(link)
+		if err != nil {
+			return
+		}
+		absUrl := baseUrl.ResolveReference(refUrl)
+		link = absUrl.String()
 		dt, ok := s.Parent().Next().Next().Attr("datetime")
 		if !ok {
 			return

--- a/lib/prtimes_source_test.go
+++ b/lib/prtimes_source_test.go
@@ -28,6 +28,6 @@ func TestGetPRTimesFromReader(t *testing.T) {
 
 	assert.Equal(t, 20, len(feed.Items))
 	assert.Equal(t, "ディズニー、スヌーピー、サンリオ、ポケモンなどの人気キャラクターを取り入れた最旬トレンドファッション“キャラディネート”を一冊に！", feed.Items[0].Title)
-	assert.Equal(t, "/main/html/rd/p/000000431.000005069.html", feed.Items[0].Link.Href)
+	assert.Equal(t, "http://prtimes.jp/main/html/rd/p/000000431.000005069.html", feed.Items[0].Link.Href)
 	assert.WithinDuration(t, time.Date(2016, 9, 16, 19, 10, 39, 0, loc), feed.Items[0].Created, 0)
 }


### PR DESCRIPTION
If `atom:link`'s `href` attribute has a relative IRI reference,
feed processors dereference it by URI of the atom document.
For instance, <https://scraper.mono0x.net/prtimes-sanrio> has
`/main/html/rd/p/000000369.000011472.html` href attribute.
Feed processors resolve it to <https://scraper.mono0x.net/main/html/rd/p/000000369.000011472.html>.
They should resolve to <http://prtimes.jp/main/html/rd/p/000000369.000011472.html>.

Solutions suggested:

* Add `xml:base` attribute
* Or, dereference relative IRIs on server side

I don't think there is a way to add `xml:base` in [gorilla/feeds](https://github.com/gorilla/feeds). I pick the latter solution. This PR also changes `atom:id` since its value [MUST be an absolute IRI](https://tools.ietf.org/html/rfc4287#section-4.2.6).

Tested on Feedly, Firefox 47.0.1, and IE 11.0.35.
