### PR TITLE
Disable minimumReleaseAge for distroless digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,18 @@
     },
     {
       "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "gcr.io/distroless/static-debian12"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "matchManagers": [
         "gomod"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
Docker digest updates are generally unsupported by minimumReleaseAge, so the renovate/stability-days check stays pending forever and blocks merges.