### PR TITLE
Improve Renovate group PR titles for single and multiple updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "group": {
+    "commitMessageTopic": "{{#if upgrades.[1]}}{{{groupName}}}{{else}}{{{depName}}}{{/if}}",
+    "commitMessageExtra": "{{#unless upgrades.[1]}}to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}{{/unless}}"
+  },
   "packageRules": [
     {
       "matchManagers": [
@@ -55,7 +59,7 @@
         "minor",
         "patch"
       ],
-      "groupName": "actions",
+      "groupName": "GitHub Actions",
       "schedule": [
         "on the first day of the month"
       ]


### PR DESCRIPTION
Use a conditional `commitMessageTopic` so single-dependency groups show the actual dep name, and rename groups to descriptive names that read well in multi-dependency PR titles.

- Add `group.commitMessageTopic` that shows `groupName` only when a group bundles multiple updates, otherwise the individual `depName`.
- Rename `actions` to `GitHub Actions`.