### PR TITLE
Allow Dockerfile updates lacking a release timestamp

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,13 +21,7 @@
       "matchManagers": [
         "dockerfile"
       ],
-      "matchPackageNames": [
-        "gcr.io/distroless/static-debian12"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "minimumReleaseAge": null
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
The docker datasource does not provide releaseTimestamp for tags, so with the default minimumReleaseAgeBehaviour=timestamp-required every ghcr.io/jdx/mise release was marked pending forever and silently dropped from the mise group branch. Scope timestamp-optional to the dockerfile manager, which also makes the distroless minimumReleaseAge override redundant.